### PR TITLE
Fix source path for the include-more-plugins option

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ try {
 
         if (options.includeMorePlugins) {
             console.log('includeMorePlugins');
-            const pluginPath = path.join(__dirname, 'plugins');
+            const pluginPath = path.join(__dirname, 'nsis', 'plugins');
             const pluginOutput = path.join(nsis3Directory, 'plugins', 'x86-ansi');
             
             copyDirectory(pluginPath, pluginOutput);


### PR DESCRIPTION
Fixes the source path for the include-more-plugins option to match the
repository layout.