### PR TITLE
Improve verbosity detection

### DIFF
--- a/installer.js
+++ b/installer.js
@@ -90,7 +90,7 @@ class Installer {
 
         // Increase verbosity for debug
         const args = [];
-        if (this.arguments.indexOf('/V') === -1) {
+        if (this.arguments.indexOf('/V') === -1 && this.arguments.indexOf('-V') === -1) {
             if (this.debugMode) {
                 args.push('/V4');
             }


### PR DESCRIPTION
The NSIS compiler accepts all command-line flags prefixed with `-` and `/`. This PR adds verbosity detection for both prefixes.