### PR TITLE
Use fs.promises over util.promisify

### DIFF
--- a/installer.js
+++ b/installer.js
@@ -1,29 +1,29 @@
-const { promisify } = require('util');
-
-const fs = require('fs');
-const statAsync = promisify(fs.stat);
-const existsAsync = promisify(fs.exists);
-const mkdirAsync = promisify(fs.mkdir);
-const readdirAsync = promisify(fs.readdir);
-const copyFileAsync = promisify(fs.copyFile);
+const fs = require('fs').promises;
+const { F_OK } = require('fs').constants;
 
 const path = require('path');
 const makensis = require('./makensis');
 
 const isDirectoryAsync = async (item) => {
-    const stats = await statAsync(item);
+    const stats = await fs.stat(item);
     
     return stats.isDirectory();
 };
 
+const fileExists = async (item) => {
+    return await fs.access(item, F_OK)
+        .then(() => true)
+        .catch(() => false);
+}
+
 const copyDirectoryAsync = async (src, dest) => {
     console.log('copyDirectory', src, dest);
 
-    if (!await existsAsync(dest)) {
-        await mkdirAsync(dest);
+    if (!await fileExists(dest)) {
+        await fs.mkdir(dest);
     }
 
-    const items = await readdirAsync(src);
+    const items = await fs.readdir(src);
     const promises = items.map(async item => {
         const name = path.basename(item);
         const srcPath = path.join(src, name);
@@ -39,7 +39,7 @@ const copyDirectoryAsync = async (src, dest) => {
                 srcPath,
                 path.join(dest, name)
             );
-            await copyFileAsync(
+            await fs.copyFile(
                 srcPath,
                 path.join(dest, name)
             );

--- a/installer.js
+++ b/installer.js
@@ -11,9 +11,13 @@ const isDirectoryAsync = async (item) => {
 };
 
 const fileExists = async (item) => {
-    return await fs.access(item, F_OK)
-        .then(() => true)
-        .catch(() => false);
+    try {
+        await fs.access(item, F_OK)
+    } catch (err) {
+        return false;
+    }
+    
+    return true;
 }
 
 const copyDirectoryAsync = async (src, dest) => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/joncloud/nsis-action/issues"
   },
   "homepage": "https://github.com/joncloud/nsis-action#readme",
+  "engines": {
+    "node": ">=10.0.0 <15.0.0"
+  },
   "dependencies": {
     "@actions/core": "^1.2.2",
     "@actions/github": "^2.1.0"


### PR DESCRIPTION
Two changes here:

- as of Node 10, the `fs` module exposes async versions for most of its methods
- `fs.exists` has been [deprecated](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback), it's recommended to use either `fs.access` or `fs.stat` – I've added a helper function for the former